### PR TITLE
Separate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Discord bot to download user submitted raid nearby in your discord server. It sa
 ### Running order
 1. Copy config.example.py and rename to config.py. Configure config.py based on your setup.
 2. Run `python3.6 downloadfortimg.py` once to download all gym(fort) URL images
-3. Run `python3.6 raidscan.py` start raid iamge scanning
-4. Run `python3.6 rssbot.py` to start downloading user posted screenshot image on your discord server
-5. If PGSS can't find gym then the gym image is saved in `not_find_img`. Check the images in the directory and identify the gym. Then rename the image to `Fort_xxx.png` or `Pokemon_yyy.png`. Then Run `python3.6 manualsubmit.py`. `manualsubmit.py` updates `fort_id` to xxx in `raid_images` and `pokemon_id` to yyy in `pokemon_images` table.
+3. Run `python3.6 raidscan.py` start raid image scanning. With this command, `crop.py`, `raidnearby.py` and `findfort.py` run all together. If you run with `python3.6 raidscan.py NO_FINDFORT`, `findfort.py` dosen't run and need to run `findfort.py` separately. This option is recommanded when you start raid scan in new area and most of gym images are unknown.
+4. If you run `raidscan.py` with **NO_FINDFORT** option, run open another terminal and activate `venv`, then run `python3.6 findfort.py`.
+5. _Optional_. Run `python3.6 rssbot.py` to start downloading user posted screenshot image on your discord server 
+6. If PGSS can't find gym then the gym image is saved in `not_find_img`. Check the images in the directory and identify the gym. Then rename the image to `Fort_xxx.png` or `Pokemon_yyy.png`. Then Run `python3.6 manualsubmit.py`. `manualsubmit.py` updates `fort_id` to xxx in `raid_images` and `pokemon_id (Pokedex#)` to yyy in `pokemon_images` table.
 
 ## Setting up
 1. Install Python 3.6
@@ -130,7 +131,7 @@ CREATE TABLE gym_images (
     PRIMARY KEY (id)
 );
 ```
-### pokemon_images
+#### pokemon_images
 ```
 CREATE TABLE pokemon_images (
     id INTEGER NOT NULL AUTO_INCREMENT, 

--- a/crop.py
+++ b/crop.py
@@ -111,7 +111,7 @@ def exception_handler(loop, context):
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()
     loop.set_exception_handler(exception_handler)
-    loop.create_task(crop.crop_task())
+    loop.create_task(crop_task())
     loop.run_forever()
     loop.close()
 

--- a/crop.py
+++ b/crop.py
@@ -87,7 +87,7 @@ async def crop_img(fullpath_filename):
             LOG.info('Check not_find_img directory and add RAID_NEARBY_SIZE in config for the screenshot iamge')
         img = cv2.resize(img, None, fx = 0.35, fy = 0.35) 
         save_file_path = web_server_path+'screenshot.jpg'
-        cv2.imwrite(save_file_path, img)
+        cv2.imwrite(save_file_path, img, [int(cv2.IMWRITE_JPEG_QUALITY), 50])
         os.remove(fullpath_filename)
         await asyncio.sleep(0.1) 
     

--- a/crop.py
+++ b/crop.py
@@ -117,20 +117,6 @@ if __name__ == '__main__':
     loop.close()
 
 
-def exception_handler(loop, context):
-    loop.default_exception_handler(context)
-    exception = context.get('exception')
-    if isinstance(exception, Exception):
-        LOG.error("Found unhandeled exception. Stoping...")
-        loop.stop()
-
-if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.set_exception_handler(exception_handler)
-    loop.create_task(crop_task())
-    loop.run_forever()
-    loop.close()
-
 
 
 

--- a/crop.py
+++ b/crop.py
@@ -67,5 +67,20 @@ async def crop_task():
                 await asyncio.sleep(0.1) 
         await asyncio.sleep(3) # task runs every 3 seconds
 
+def exception_handler(loop, context):
+    loop.default_exception_handler(context)
+    exception = context.get('exception')
+    if isinstance(exception, Exception):
+        LOG.error("Found unhandeled exception. Stoping...")
+        loop.stop()
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.set_exception_handler(exception_handler)
+    loop.create_task(crop.crop_task())
+    loop.run_forever()
+    loop.close()
+
+
 
 

--- a/crop.py
+++ b/crop.py
@@ -101,5 +101,20 @@ async def crop_task():
             await crop_img(fullpath_filename)
         await asyncio.sleep(0.2) # task runs every 0.2 seconds
 
+def exception_handler(loop, context):
+    loop.default_exception_handler(context)
+    exception = context.get('exception')
+    if isinstance(exception, Exception):
+        LOG.error("Found unhandeled exception. Stoping...")
+        loop.stop()
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.set_exception_handler(exception_handler)
+    loop.create_task(crop.crop_task())
+    loop.run_forever()
+    loop.close()
+
+
 
 

--- a/crop.py
+++ b/crop.py
@@ -8,6 +8,7 @@ from config import SCREENSHOT_SAVE_PATH, RAID_NEARBY_SIZE
 import asyncio
 import shutil
 import math
+import raidnearby
 #import pdb; pdb.set_trace()
 
 LOG = getLogger('')

--- a/crop.py
+++ b/crop.py
@@ -77,7 +77,7 @@ def exception_handler(loop, context):
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()
     loop.set_exception_handler(exception_handler)
-    loop.create_task(crop.crop_task())
+    loop.create_task(crop_task())
     loop.run_forever()
     loop.close()
 

--- a/findfort.py
+++ b/findfort.py
@@ -155,7 +155,7 @@ def exception_handler(loop, context):
         loop.stop()
 
 if __name__ == '__main__':
-    find_fort = findfort.FindFort()
+    find_fort = FindFort()
     loop = asyncio.get_event_loop()
     loop.set_exception_handler(exception_handler)
     loop.create_task(find_fort.findfort_main())

--- a/findfort.py
+++ b/findfort.py
@@ -147,11 +147,20 @@ class FindFort:
         LOG.info('Done')
         return
     
-if __name__ == '__main__':
-    findfort = FindFort()
-    findfort.findfort_main()
+def exception_handler(loop, context):
+    loop.default_exception_handler(context)
+    exception = context.get('exception')
+    if isinstance(exception, Exception):
+        LOG.error("Found unhandeled exception. Stoping...")
+        loop.stop()
 
-                    
+if __name__ == '__main__':
+    find_fort = findfort.FindFort()
+    loop = asyncio.get_event_loop()
+    loop.set_exception_handler(exception_handler)
+    loop.create_task(find_fort.findfort_main())
+    loop.run_forever()
+    loop.close()                    
                     
                     
             

--- a/raidnearby.py
+++ b/raidnearby.py
@@ -45,6 +45,13 @@ LOG.addHandler(rfh)
 
 LOG.info('Pokemon Screenshot Raid Scan Started')
 
+def exception_handler(loop, context):
+    loop.default_exception_handler(context)
+    exception = context.get('exception')
+    if isinstance(exception, Exception):
+        LOG.error("Found unhandeled exception. Stoping...")
+        loop.stop()
+
 class RaidNearby:
     def __init__(self):
         self.process_img_path = os.getcwd() + '/process_img/'
@@ -598,12 +605,14 @@ class RaidNearby:
             await asyncio.sleep(3) 
         self.session.close()
 
+
+
 if __name__ == '__main__':
-    raidnearby = RaidNearby()
-    filename = 'test_file.png'
-    raidfilename = os.getcwd() + '/not_find_img/' + filename
-    raidnearby.processRaidImage(raidfilename)
-    
-#    main()
+    raid_nearby = raidnearby.RaidNearby()
+    loop = asyncio.get_event_loop()
+    loop.set_exception_handler(exception_handler)
+    loop.create_task(raid_nearby.main())
+    loop.run_forever()
+    loop.close()
 
 

--- a/raidnearby.py
+++ b/raidnearby.py
@@ -608,7 +608,7 @@ class RaidNearby:
 
 
 if __name__ == '__main__':
-    raid_nearby = raidnearby.RaidNearby()
+    raid_nearby = RaidNearby()
     loop = asyncio.get_event_loop()
     loop.set_exception_handler(exception_handler)
     loop.create_task(raid_nearby.main())

--- a/raidnearby.py
+++ b/raidnearby.py
@@ -458,6 +458,10 @@ class RaidNearby:
     async def processRaidImage(self, raidfilename):
         filename = os.path.basename(raidfilename)
         img_full = cv2.imread(str(raidfilename),3)
+        
+        if img_full is None:
+            return False
+        
         filename_no_ext, ext = os.path.splitext(filename) 
 
         now = datetime.datetime.now()
@@ -602,7 +606,7 @@ class RaidNearby:
                 LOG.debug('process {}'.format(fullpath_filename))
                 await self.processRaidImage(fullpath_filename)
                 await asyncio.sleep(0.1)
-            await asyncio.sleep(3) 
+            await asyncio.sleep(1) 
         self.session.close()
 
 

--- a/raidnearby.py
+++ b/raidnearby.py
@@ -45,6 +45,13 @@ LOG.addHandler(rfh)
 
 LOG.info('Pokemon Screenshot Raid Scan Started')
 
+def exception_handler(loop, context):
+    loop.default_exception_handler(context)
+    exception = context.get('exception')
+    if isinstance(exception, Exception):
+        LOG.error("Found unhandeled exception. Stoping...")
+        loop.stop()
+
 class RaidNearby:
     def __init__(self):
         self.process_img_path = os.getcwd() + '/process_img/'
@@ -603,12 +610,14 @@ class RaidNearby:
             await asyncio.sleep(1) 
         self.session.close()
 
+
+
 if __name__ == '__main__':
-    raidnearby = RaidNearby()
-    filename = 'test_file.png'
-    raidfilename = os.getcwd() + '/not_find_img/' + filename
-    raidnearby.processRaidImage(raidfilename)
-    
-#    main()
+    raid_nearby = raidnearby.RaidNearby()
+    loop = asyncio.get_event_loop()
+    loop.set_exception_handler(exception_handler)
+    loop.create_task(raid_nearby.main())
+    loop.run_forever()
+    loop.close()
 
 

--- a/raidnearby.py
+++ b/raidnearby.py
@@ -613,7 +613,7 @@ class RaidNearby:
 
 
 if __name__ == '__main__':
-    raid_nearby = raidnearby.RaidNearby()
+    raid_nearby = RaidNearby()
     loop = asyncio.get_event_loop()
     loop.set_exception_handler(exception_handler)
     loop.create_task(raid_nearby.main())

--- a/raidscan.py
+++ b/raidscan.py
@@ -1,4 +1,5 @@
 import sys
+from sys import argv
 import datetime
 from logging import basicConfig, getLogger, FileHandler, StreamHandler, DEBUG, INFO, ERROR, Formatter
 import time
@@ -10,6 +11,13 @@ import os
 import concurrent.futures
 
 LOG = getLogger('')
+
+no_findfort = False
+if len(argv) >= 2:
+    if str(argv[1]) == 'NO_FINDFORT':
+        no_findfort = True
+        LOG.info('No findfort option selected.')
+        LOG.info('Run findfort.py separately to identify new unknown gyms')
 
 cpu_count = os.cpu_count()
 LOG.info('{} cpu cores found'.format(cpu_count))
@@ -23,13 +31,15 @@ def exception_handler(loop, context):
 
 if __name__ == '__main__':
     raid_nearby = raidnearby.RaidNearby()
-    find_fort = findfort.FindFort()
+    if no_findfort == False:
+        find_fort = findfort.FindFort()
     loop = asyncio.get_event_loop()
     loop.set_exception_handler(exception_handler)
     executor = concurrent.futures.ProcessPoolExecutor(max_workers=cpu_count)
     loop.set_default_executor(executor)
     loop.create_task(raid_nearby.main())
-    loop.create_task(find_fort.findfort_main())
+    if no_findfort == False:    
+        loop.create_task(find_fort.findfort_main())
     loop.create_task(crop.crop_task())
     loop.run_forever()
     loop.close()


### PR DESCRIPTION
1. **NO_FINDFORT** options added to `raidscan.py`. If you run with `python3.6 raidscan.py NO_FINDFORT`, `findfort.py` dosen't run and need to run `findfort.py` separately. This option is recommanded when you start raid scan in new area and most of gym images are unknown. To run `findfort.py` separately just run `python3.6 findfort.py` in `venv` activated terminal. 
2. `crop.py` can run individually to just move/crop screenshots from `SCREENSHOT_SAVE_PATH` to `process_img`. run `python3.6 crop.py` in another `venv` activated terminal.