### PR TITLE
Utilize spatial queries to retrieve gyms within SCAN_AREA on raidscan init

### DIFF
--- a/database.py
+++ b/database.py
@@ -472,7 +472,7 @@ def get_forts_inside_scan_area(session):
         # Strip trailing comma
         poly_coords = poly_coords[:-1]
         
-    results = session.execute('SELECT id, lat, lon FROM forts WHERE ST_CONTAINS(ST_GEOMFROMTEXT(\'POLYGON((' + poly_coords + '))\'), ST_POINT(lon, lat))')
+    results = session.execute('SELECT id, lat, lon FROM forts WHERE lat IS NOT NULL AND ST_CONTAINS(ST_GEOMFROMTEXT(\'POLYGON((' + poly_coords + '))\'), ST_POINTFROMTEXT(CONCAT(\'POINT(\', lon, \' \', lat, \')\')))')
     session.commit()
     
     for row in results:

--- a/database.py
+++ b/database.py
@@ -504,11 +504,18 @@ def get_fort_ids_within_range(session, forts, range, lat, lon):
 
     return ids
     
-def check_postgis_version(session):
-    results = session.execute('SELECT extversion FROM pg_catalog.pg_extension WHERE extname=\'postgis\'')
-    session.commit()
-    result = results.fetchone()
-    return result[0] if result is not None else None
+def is_spatial_capable(session):
+    is_capable = False
+    
+    if config.DB_ENGINE.startswith('mysql'):
+        is_capable = True
+    elif config.DB_ENGINE.startswith('postgres'):
+        results = session.execute('SELECT extversion FROM pg_catalog.pg_extension WHERE extname=\'postgis\'')
+        session.commit()
+        result = results.fetchone()
+        is_capable = True if result is not None else False
+        
+    return is_capable
 
 def float_to_str(f):
     """

--- a/downloadfortimg.py
+++ b/downloadfortimg.py
@@ -47,10 +47,10 @@ def main():
     if (config.MAP_START[0] == 0 and config.MAP_START[1] == 0) or (config.MAP_END[0] == 0 and config.MAP_END[1] == 0):
         check_boundary = False
     else:
-        north = max(MAP_START[0], MAP_END[0])
-        south = min(MAP_START[0], MAP_END[0])
-        east = max(MAP_START[1], MAP_END[1])
-        west = min(MAP_START[1], MAP_END[1])
+        north = max(config.MAP_START[0], config.MAP_END[0])
+        south = min(config.MAP_START[0], config.MAP_END[0])
+        east = max(config.MAP_START[1], config.MAP_END[1])
+        west = min(config.MAP_START[1], config.MAP_END[1])
 
     all_forts = [fort for fort in database.get_forts(session)]
     print('{} forts find in database. Start downloading.'.format(len(all_forts)))

--- a/raidscan.py
+++ b/raidscan.py
@@ -42,7 +42,7 @@ class RaidScan:
             postgis_version = database.check_postgis_version(session)
             all_forts = []
             
-            if self.config.SCAN_AREA != 'All' && postgis_version is not None:
+            if self.config.SCAN_AREA != 'All' and postgis_version is not None:
                 all_forts = database.get_forts_inside_scan_area(session)
             else:
                 all_forts = database.get_forts(session)            

--- a/raidscan.py
+++ b/raidscan.py
@@ -39,10 +39,10 @@ class RaidScan:
             LOG.info('Scan-Area is set! Getting Forts...')
             session = database.Session()
             
-            postgis_version = database.check_postgis_version(session)
+            is_spatial_capable = database.is_spatial_capable(session)
             all_forts = []
             
-            if self.config.SCAN_AREA != 'All' and postgis_version is not None:
+            if self.config.SCAN_AREA != 'All' and is_spatial_capable:
                 all_forts = database.get_forts_inside_scan_area(session)
             else:
                 all_forts = database.get_forts(session)            

--- a/raidscan.py
+++ b/raidscan.py
@@ -38,13 +38,24 @@ class RaidScan:
 
             LOG.info('Scan-Area is set! Getting Forts...')
             session = database.Session()
-            all_forts = database.get_forts(session)
+            
+            postgis_version = database.check_postgis_version(session)
+            all_forts = []
+            
+            if self.config.SCAN_AREA != 'All' && postgis_version is not None:
+                all_forts = database.get_forts_inside_scan_area(session)
+            else:
+                all_forts = database.get_forts(session)            
 
             all_forts_to_download = []
 
             session2 = database.Session()
 
+            i = 0;
+
             for fort in all_forts:
+                i = i + 1
+                LOG.info('Processing gym {} of {}'.format(i, len(all_forts)))
                 if fort.lat is not None and fort.lon is not None and self.config.SCAN_AREA == 'All':
                     all_forts_to_download.append(fort.id)
                     self.all_forts_inside.append(DBFort(fort.id, fort.lat, fort.lon, 0))


### PR DESCRIPTION
Currently, on RaidScan.__init__, all forts are retrieved from the database and are checked to see if they are within the SCAN_AREA polygon/boundaries.  For implementations where there is a large number of forts in the database, this process proved to be excruciatingly slow and took near 45 minutes to begin control for approximately 47k forts.

Spatial queries will instead be used to retrieve forts ONLY within the SCAN_AREA polygon/boundaries.  Depending on how large the SCAN_AREA is, startup went from ~45 minutes to about 5 seconds.

For PostgreSQL implementations, please install PostGIS and create the extension for your monocle database (https://postgis.net/).

MySQL implementations should support spatial queries natively.